### PR TITLE
Fix: Fix bug where $VARIANT['tag_without_distro'] contained contiguous '-' in certain cases

### DIFF
--- a/src/Generate-DockerImageVariants/Generate-DockerImageVariants.psm1
+++ b/src/Generate-DockerImageVariants/Generate-DockerImageVariants.psm1
@@ -315,7 +315,7 @@ function Generate-DockerImageVariants {
                                                         # E.g. ':git-perl-alpine' or 'alpine-git-perl' becomes ':git-perl'
                                                         $variant_distro_regex = [regex]::Escape( $VARIANT['distro'] )
                                                         if ( $VARIANT['tag'] -match "^(.*)$variant_distro_regex(.*)$" ) {
-                                                            "$( $matches[1] )-$( $matches[2] )".Trim('-')
+                                                            "$( $matches[1].Trim('-') )-$( $matches[2].Trim('-') )".Trim('-')
                                                         }else {
                                                             $VARIANT['tag']
                                                         }


### PR DESCRIPTION
This occurs when $VARIANT['distro'] was a intermediate component i.e.  at beginning or end of $VARIANT['tag'].

E.g.

```
$VARIANT = @{
  tag = 'my-alpine-foo'
  distro = alpine
}
```

which results in

```
$VARIANT = @{
  tag = 'my-alpine-foo'
  distro = alpine
  tag_without_distro = 'my--foo'
}
```