### PR TITLE
Docs: Fix readme examples of variants generation to no longer be organized by distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,13 +379,12 @@ Upon generation, **three** variants build contexts for variants `curl-git`, `cur
 ```sh
 .
 └── variants
-|   └── alpine
-|       └── curl-git
-|           └── Dockerfile
-|       └── curl
-|           └── Dockerfile
-|       └── git
-|           └── Dockerfile
+|   └── curl-git
+|       └── Dockerfile
+|   └── curl
+|       └── Dockerfile
+|   └── git
+|       └── Dockerfile
 ```
 
 See the [`examples/advanced-component-chaining-copies-variables`](examples/advanced-component-chaining-copies-variables) example.


### PR DESCRIPTION
Unfinished changes to readme in #18 