### PR TITLE
Fix: Fix regression that resulted variant files not being generated

### DIFF
--- a/src/Generate-DockerImageVariants/Generate-DockerImageVariants.Integration.Tests.ps1
+++ b/src/Generate-DockerImageVariants/Generate-DockerImageVariants.Integration.Tests.ps1
@@ -1,5 +1,3 @@
-
-
 Describe 'Generate-DockerImageVariants' -Tag 'Integration' {
 
     $PROJECT_DIR = Convert-Path "$PSScriptRoot/../../"
@@ -32,16 +30,16 @@ Describe 'Generate-DockerImageVariants' -Tag 'Integration' {
 
             Generate-DockerImageVariants -Init -ProjectPath $testProjectDir 6>&1 > $null
 
-            $testProjectGenerateDir | Get-Item | Should -BeOfType [System.IO.DirectoryInfo]
-            $testProjectGenerateDefinitionsDir | Get-Item | Should -BeOfType [System.IO.DirectoryInfo]
-            $testProjectGenerateTemplatesDir | Get-Item | Should -BeOfType [System.IO.DirectoryInfo]
+            $testProjectGenerateDir | Get-Item -Force | Should -BeOfType [System.IO.DirectoryInfo]
+            $testProjectGenerateDefinitionsDir | Get-Item -Force | Should -BeOfType [System.IO.DirectoryInfo]
+            $testProjectGenerateTemplatesDir | Get-Item -Force| Should -BeOfType [System.IO.DirectoryInfo]
 
-            $testProjectGenerateDefinitionsFiles | Get-Item | Should -BeOfType [System.IO.FileInfo]
-            $testProjectGenerateDefinitionsVariants | Get-Item | Should -BeOfType [System.IO.FileInfo]
+            $testProjectGenerateDefinitionsFiles | Get-Item -Force | Should -BeOfType [System.IO.FileInfo]
+            $testProjectGenerateDefinitionsVariants | Get-Item -Force | Should -BeOfType [System.IO.FileInfo]
 
-            $testProjectGenerateTemplatesDockerfile | Get-Item | Should -BeOfType [System.IO.FileInfo]
-            $testProjectGenerateTemplatesReadmeMd | Get-Item | Should -BeOfType [System.IO.FileInfo]
-            $testProjectGenerateTemplatesGitlabCiYml | Get-Item | Should -BeOfType [System.IO.FileInfo]
+            $testProjectGenerateTemplatesDockerfile | Get-Item -Force | Should -BeOfType [System.IO.FileInfo]
+            $testProjectGenerateTemplatesReadmeMd | Get-Item -Force | Should -BeOfType [System.IO.FileInfo]
+            $testProjectGenerateTemplatesGitlabCiYml | Get-Item -Force | Should -BeOfType [System.IO.FileInfo]
 
             # Cleanup
             Get-Item $testProjectDir | Remove-Item -Recurse -Force
@@ -79,6 +77,22 @@ Describe 'Generate-DockerImageVariants' -Tag 'Integration' {
             @( $infoStream | ? { $_.MessageData.Message -cmatch '^Creating definition file' }).Count | Should -Be 1
             @( $infoStream | ? { $_.MessageData.Message -cmatch '^Not creating template file' }).Count | Should -Be 1
             @( $infoStream | ? { $_.MessageData.Message -cmatch '^Creating template file' }).Count | Should -Be 2
+
+            # Cleanup
+            Get-Item $testProjectDir | Remove-Item -Recurse -Force
+        }
+
+        It 'Should generate files for default prototypes created by -Init' {
+            # Mock project
+            $testProjectDir = "TestDrive:\test-project"
+            New-Item $testProjectDir -ItemType Directory > $null
+
+            Generate-DockerImageVariants -ProjectPath $testProjectDir -Init -ErrorAction Stop #6>$null
+            Generate-DockerImageVariants -ProjectPath $testProjectDir -ErrorAction Stop 6>$null
+
+            Test-Path $testProjectDir/variants/curl/Dockerfile | Should -Be $true
+            Test-Path $testProjectDir/variants/curl-git/Dockerfile | Should -Be $true
+            Test-Path $testProjectDir/variants/my-cool-variant/Dockerfile | Should -Be $true
 
             # Cleanup
             Get-Item $testProjectDir | Remove-Item -Recurse -Force

--- a/src/Generate-DockerImageVariants/private/New-RepositoryVariantBuildContext.ps1
+++ b/src/Generate-DockerImageVariants/private/New-RepositoryVariantBuildContext.ps1
@@ -26,7 +26,7 @@ function New-RepositoryVariantBuildContext {
 
         if ($Variant.Contains('buildContextFiles')) {
             # Generate files from templates
-            if ( $Variant['buildContextFiles'].Contains('templates') -and $Variant['buildContextFiles']['templates'] -is [hashtable] ) {
+            if ($VARIANT['buildContextFiles'].Contains('templates')) {
                 foreach ($k in $Variant['buildContextFiles']['templates'].Keys) {
                     $template = $Variant['buildContextFiles']['templates'][$k]
                     foreach ($pass in $template['passes']) {
@@ -43,7 +43,7 @@ function New-RepositoryVariantBuildContext {
                             Get-ContextFileContent @params
                         }
                         New-Item $pass['file'] -ItemType File -Force > $null
-                        $content | Out-File $pass['file'] -Encoding Utf8 -Force -NoNewline -Force
+                        $content | Out-File $pass['file'] -Encoding Utf8 -NoNewline -Force
                     }
                 }
             }

--- a/src/Generate-DockerImageVariants/private/Populate-GenerateConfig.ps1
+++ b/src/Generate-DockerImageVariants/private/Populate-GenerateConfig.ps1
@@ -41,7 +41,7 @@ function Populate-GenerateConfig {
 
         if ($VARIANT.Contains('buildContextFiles')) {
             # Populate the templates object
-            if ( $VARIANT['buildContextFiles'].Contains('templates') -and $VARIANT['buildContextFiles']['templates'] -is [hashtable] ) {
+            if ($VARIANT['buildContextFiles'].Contains('templates')) {
                 foreach ($k in $VARIANT['buildContextFiles']['templates'].Keys) {
                     $VARIANT['buildContextFiles']['templates'][$k]['file'] = $k
                     # Dynamically determine the sub templates from the name of the variant. (E.g. 'foo-bar' will comprise of foo and bar variant sub templates for this template file)

--- a/src/Generate-DockerImageVariants/public/Generate-DockerImageVariants.Tests.ps1
+++ b/src/Generate-DockerImageVariants/public/Generate-DockerImageVariants.Tests.ps1
@@ -11,7 +11,12 @@ Describe "Generate-DockerImageVariants" -Tag 'Unit' {
     function Get-VariantsPrototype {}
     function Get-FilesPrototype {}
     function Validate-Object {}
-    function Populate-GenerateConfig {}
+    function Populate-GenerateConfig {
+        param (
+            $GenerateConfig
+        )
+        $GenerateConfig
+    }
     function New-RepositoryVariantBuildContext {}
     function New-RepositoryFile {}
 
@@ -148,7 +153,12 @@ Describe "Generate-DockerImageVariants" -Tag 'Unit' {
                 $GenerateConfig
             }
             Mock Test-Path -ParameterFilter { $Path -eq 'files.ps1' } { $true }
-            Mock Populate-GenerateConfig {}
+            Mock Populate-GenerateConfig {
+                param (
+                    $GenerateConfig
+                )
+                $GenerateConfig
+            }
 
             Generate-DockerImageVariants -ProjectPath $projectPath
 

--- a/src/Generate-DockerImageVariants/public/Generate-DockerImageVariants.ps1
+++ b/src/Generate-DockerImageVariants/public/Generate-DockerImageVariants.ps1
@@ -63,7 +63,7 @@ function Generate-DockerImageVariants {
                 }
 
                 # Populate and normalize definitions
-                Populate-GenerateConfig -GenerateConfig $GenerateConfig
+                $GenerateConfig = Populate-GenerateConfig -GenerateConfig $GenerateConfig
 
                 # Generate each Docker image variant's build context files
                 & {


### PR DESCRIPTION
Fixes a critical regression in #32 that resulted in the compiled variant configuration not being used, leading to no files being generated.

This bug affects all version since `v0.3.0`