### PR TITLE
Fix (ci): Bump runner from `ubuntu-16.04` to `ubuntu-18.04`

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -15,18 +15,6 @@ jobs:
     runs-on: windows-2016
     steps:
     - uses: actions/checkout@v2
-    - name: Display system info (windows)
-      run: |
-        Set-StrictMode -Version Latest; $ErrorActionPreference = 'Stop'
-        hostname
-        whoami
-        systeminfo
-        Get-PSDrive
-        Get-Location
-        # pwsh version
-        $PSVersionTable
-        # Windows Powershell version?
-        powershell -Command '$PSVersionTable'
     - name: Powershell version
       run: |
         powershell -NoLogo -NonInteractive -NoProfile -Command '$PSVersionTable'
@@ -38,18 +26,6 @@ jobs:
     runs-on: windows-2019
     steps:
     - uses: actions/checkout@v2
-    - name: Display system info (windows)
-      run: |
-        Set-StrictMode -Version Latest; $ErrorActionPreference = 'Stop'
-        hostname
-        whoami
-        systeminfo
-        Get-PSDrive
-        Get-Location
-        # pwsh version
-        $PSVersionTable
-        # Windows Powershell version?
-        powershell -Command '$PSVersionTable'
     - name: Powershell version
       run: |
         powershell -NoLogo -NonInteractive -NoProfile -Command '$PSVersionTable'
@@ -57,57 +33,15 @@ jobs:
       run: |
         powershell -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
-  # ubuntu-16-04:
-  #   runs-on: ubuntu-16.04
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Display system info (linux)
-  #     run: |
-  #       set -e
-  #       hostname
-  #       whoami
-  #       cat /etc/*release
-  #       lscpu
-  #       free
-  #       df -h
-  #       pwd
-  #       docker info
-  #       docker version
-
-  # macos-10-15:
-  #   runs-on: macos-10.15
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Display system info (macos)
-  #     run: |
-  #       set -e
-  #       hostname
-  #       whoami
-  #       df -h
-  #       pwd
-  #       # docker info
-  #       # docker version
-
   ##########
   # Docker #
   ##########
   test-powershell-6-0:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     container:
-      # image: theohbrothers/docker-powershell:6.0.2-ubuntu-16.04-git
       image: mcr.microsoft.com/powershell:6.0.2-ubuntu-16.04
     steps:
     - uses: actions/checkout@v2
-    - name: Display system info (linux)
-      run: |
-        set -e
-        hostname
-        whoami
-        cat /etc/*release
-        lscpu
-        free
-        df -h
-        pwd
     - name: Powershell version
       run: |
         pwsh -NoLogo -NonInteractive -NoProfile -Command '$PSVersionTable'
@@ -116,23 +50,11 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-6-1:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     container:
-      # image: theohbrothers/docker-powershell:6.1.3-alpine-3.8-git
-      # image: mcr.microsoft.com/powershell:6.1.3-alpine-3.8
       image: mcr.microsoft.com/powershell:6.1.3-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Display system info (linux)
-      run: |
-        set -e
-        hostname
-        whoami
-        cat /etc/*release
-        # lscpu
-        free
-        df -h
-        pwd
     - name: Powershell version
       run: |
         pwsh -NoLogo -NonInteractive -NoProfile -Command '$PSVersionTable'
@@ -141,23 +63,11 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-6-2:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     container:
-      # image: theohbrothers/docker-powershell:6.2.4-alpine-3.8-git
-      # image: mcr.microsoft.com/powershell:6.2.4-alpine-3.8
       image: mcr.microsoft.com/powershell:6.2.4-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Display system info (linux)
-      run: |
-        set -e
-        hostname
-        whoami
-        cat /etc/*release
-        # lscpu
-        free
-        df -h
-        pwd
     - name: Powershell version
       run: |
         pwsh -NoLogo -NonInteractive -NoProfile -Command '$PSVersionTable'
@@ -166,23 +76,11 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-7-0:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     container:
-      # image: theohbrothers/docker-powershell:7.0.3-alpine-3.9-20200928
-      # image: mcr.microsoft.com/powershell:7.0.3-alpine-3.9
       image: mcr.microsoft.com/powershell:7.0.3-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Display system info (linux)
-      run: |
-        set -e
-        hostname
-        whoami
-        cat /etc/*release
-        # lscpu
-        free
-        df -h
-        pwd
     - name: Powershell version
       run: |
         pwsh -NoLogo -NonInteractive -NoProfile -Command '$PSVersionTable'
@@ -191,23 +89,11 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-7-1:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     container:
-      # image: theohbrothers/docker-powershell:7.1.3-alpine-3.11-20210316-git
-      # image: mcr.microsoft.com/powershell:7.1.3-alpine-3.11-20210316
       image: mcr.microsoft.com/powershell:7.1.3-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Display system info (linux)
-      run: |
-        set -e
-        hostname
-        whoami
-        cat /etc/*release
-        # lscpu
-        free
-        df -h
-        pwd
     - name: Powershell version
       run: |
         pwsh -NoLogo -NonInteractive -NoProfile -Command '$PSVersionTable'
@@ -216,23 +102,11 @@ jobs:
         pwsh -NoLogo -NonInteractive -NoProfile -Command './test/test.ps1'
 
   test-powershell-7-2:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     container:
-      # image: theohbrothers/docker-powershell:7.2.0-preview.4-alpine-3.11-20210316-git
-      # image: mcr.microsoft.com/powershell:7.2.0-preview.4-alpine-3.11-20210316
       image: mcr.microsoft.com/powershell:7.2.0-preview.4-ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Display system info (linux)
-      run: |
-        set -e
-        hostname
-        whoami
-        cat /etc/*release
-        # lscpu
-        free
-        df -h
-        pwd
     - name: Powershell version
       run: |
         pwsh -NoLogo -NonInteractive -NoProfile -Command '$PSVersionTable'


### PR DESCRIPTION
`ubuntu-16.04` is no longer supported.